### PR TITLE
Mensagem de confirmação para usuário que avaliar de 0 a 3 ou de 9 a 10

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ class AppWidget extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.blue,
+          seedColor: Colors.deepPurpleAccent,
           brightness: Brightness.light,
         ),
         inputDecorationTheme: const InputDecorationTheme(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ class AppWidget extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.deepPurpleAccent,
+          seedColor: Colors.blue,
           brightness: Brightness.light,
         ),
         inputDecorationTheme: const InputDecorationTheme(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.1.1"
   path:
     dependency: transitive
     description:

--- a/lib/src/nps_page.dart
+++ b/lib/src/nps_page.dart
@@ -52,11 +52,11 @@ class _NPSPageState extends State<NPSPage> {
       barrierDismissible: false,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text('Confirmation'),
+          title: const Text('Confirmação'),
           content: SizedBox(
             width: MediaQuery.of(context).size.width * 0.4,
             child: const Text(
-              'Your opinion is very important! If you wish, share your comment and your phone number, as this will help us improve our services and strengthen our partnership. We sincerely thank you for your contribution!',
+              'Sua opinião é muito importante! Se desejar, compartilhe seu comentário e seu telefone, pois isso nos ajudará a melhorar nossos serviços e fortalecer nossa parceria. Agradecemos sinceramente pela sua contribuição!',
             ),
           ),
           actions: [
@@ -66,7 +66,7 @@ class _NPSPageState extends State<NPSPage> {
                 store.jumpToNextPage(store.currentNPS);
                 isConfirmationDialogOpen = true;
               },
-              child: const Text('Leave Comment'),
+              child: const Text('Deixe um comentário'),
             ),
             OutlinedButton(
               onPressed: () {
@@ -86,7 +86,7 @@ class _NPSPageState extends State<NPSPage> {
                 );
                 isConfirmationDialogOpen = false;
               },
-              child: const Text('To close'),
+              child: const Text('Fechar'),
             ),
           ],
         );

--- a/lib/src/nps_page.dart
+++ b/lib/src/nps_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import 'nps_store.dart';
 import 'widgets/widgets.dart';
 
@@ -12,7 +11,6 @@ class NPSPage extends StatefulWidget {
   final String? buttonLabel;
   final String? feedbackHintLabel;
   final String? phoneHintLabel;
-
   const NPSPage({
     super.key,
     this.feedbackTitle,
@@ -24,14 +22,12 @@ class NPSPage extends StatefulWidget {
     this.feedbackHintLabel,
     this.phoneHintLabel,
   });
-
   @override
   State<NPSPage> createState() => _NPSPageState();
 }
 
 class _NPSPageState extends State<NPSPage> {
   late final NpsStore store;
-
   @override
   void initState() {
     store = NpsStore();
@@ -44,19 +40,69 @@ class _NPSPageState extends State<NPSPage> {
     super.dispose();
   }
 
+  bool isConfirmationDialogOpen = false;
+  Future<void> showConfirmationDialog() async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Confirmation'),
+          content: SizedBox(
+            width: MediaQuery.of(context).size.width * 0.4,
+            child: const Text(
+              'Your opinion is very important! If you wish, share your comment and your phone number, as this will help us improve our services and strengthen our partnership. We sincerely thank you for your contribution!',
+            ),
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                store.jumpToNextPage(store.currentNPS);
+                isConfirmationDialogOpen = true;
+              },
+              child: const Text('Leave Comment'),
+            ),
+            OutlinedButton(
+              onPressed: () {
+                Navigator.of(context).pop(); // Vai fechar o AlertDialog
+                Navigator.of(context).pop(); // Vai fechar o modal de NPS
+                store.jumpToPreviusPage();
+                isConfirmationDialogOpen = false;
+              },
+              child: const Text('To close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: store,
       builder: (context, snapshot) {
         void sendNPS() {
-          Navigator.of(context).pop(
-            (
-              nps: store.currentNPS,
-              message: store.feedback,
-              phone: store.phone,
-            ),
-          );
+          // Vai verificar se o campo de comentário e telefone estão vazios
+          bool isCommentEmpty = store.feedback.trim().isEmpty;
+          bool isPhoneEmpty = store.phone.trim().isEmpty;
+          // Se o campo de comentário ou telefone estiverem vazios, exibirá a confirmação
+          if (isCommentEmpty &&
+              isPhoneEmpty &&
+              ((store.currentNPS >= 0 && store.currentNPS <= 3) ||
+                  (store.currentNPS >= 9 && store.currentNPS <= 10))) {
+            showConfirmationDialog();
+          } else {
+            // Caso contrário, fechará a página e retornará os dados
+            Navigator.of(context).pop(
+              (
+                nps: store.currentNPS,
+                message: store.feedback,
+                phone: store.phone,
+              ),
+            );
+          }
         }
 
         return PageView(

--- a/lib/src/nps_page.dart
+++ b/lib/src/nps_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'nps_store.dart';
 import 'widgets/widgets.dart';
 
@@ -11,6 +12,7 @@ class NPSPage extends StatefulWidget {
   final String? buttonLabel;
   final String? feedbackHintLabel;
   final String? phoneHintLabel;
+
   const NPSPage({
     super.key,
     this.feedbackTitle,
@@ -22,12 +24,14 @@ class NPSPage extends StatefulWidget {
     this.feedbackHintLabel,
     this.phoneHintLabel,
   });
+
   @override
   State<NPSPage> createState() => _NPSPageState();
 }
 
 class _NPSPageState extends State<NPSPage> {
   late final NpsStore store;
+
   @override
   void initState() {
     store = NpsStore();
@@ -41,6 +45,7 @@ class _NPSPageState extends State<NPSPage> {
   }
 
   bool isConfirmationDialogOpen = false;
+
   Future<void> showConfirmationDialog() async {
     return showDialog<void>(
       context: context,
@@ -65,9 +70,20 @@ class _NPSPageState extends State<NPSPage> {
             ),
             OutlinedButton(
               onPressed: () {
-                Navigator.of(context).pop(); // Vai fechar o AlertDialog
-                Navigator.of(context).pop(); // Vai fechar o modal de NPS
-                store.jumpToPreviusPage();
+                Navigator.of(context).pop(
+                  (
+                    nps: store.currentNPS,
+                    message: store.feedback,
+                    phone: store.phone,
+                  ),
+                );
+                Navigator.of(context).pop(
+                  (
+                    nps: store.currentNPS,
+                    message: store.feedback,
+                    phone: store.phone,
+                  ),
+                );
                 isConfirmationDialogOpen = false;
               },
               child: const Text('To close'),
@@ -84,17 +100,15 @@ class _NPSPageState extends State<NPSPage> {
       listenable: store,
       builder: (context, snapshot) {
         void sendNPS() {
-          // Vai verificar se o campo de comentário e telefone estão vazios
           bool isCommentEmpty = store.feedback.trim().isEmpty;
           bool isPhoneEmpty = store.phone.trim().isEmpty;
-          // Se o campo de comentário ou telefone estiverem vazios, exibirá a confirmação
+
           if (isCommentEmpty &&
               isPhoneEmpty &&
               ((store.currentNPS >= 0 && store.currentNPS <= 3) ||
                   (store.currentNPS >= 9 && store.currentNPS <= 10))) {
             showConfirmationDialog();
           } else {
-            // Caso contrário, fechará a página e retornará os dados
             Navigator.of(context).pop(
               (
                 nps: store.currentNPS,


### PR DESCRIPTION
Se o usuário fizer uma votação no `NPS` de `0-3` ou de `9-10` se estiver vazio o comentário/telefone, automaticamente abrirá um modal para confirmação com uma mensagem para que o usuário possa voltar e responder com comentário ou telefone, ou ele poderá fechar o NPS caso não queira responder com comentário e telefone. Caso ele clique para fechar, ainda sim vai capturar a avaliação de NPS selecionada.